### PR TITLE
Do not run containers by root

### DIFF
--- a/templates/core/core-dpl.yaml
+++ b/templates/core/core-dpl.yaml
@@ -38,6 +38,27 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      initContainers:
+      - name: "install-certificates"
+        securityContext:
+          runAsUser: 0
+        image: {{ .Values.core.image.repository }}:{{ .Values.core.image.tag }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        command: ["/bin/sh"]
+        args: [
+          '-c',
+          '/usr/bin/harbor-install-cert.sh && cp -ar /var/lib/ca-certificates/* /tmp/ca-certificates' ]
+        volumeMounts:
+        - name: ca-certificates
+          mountPath: /tmp/ca-certificates
+          readOnly: false
+        {{- if .Values.internalTLS.enabled }}
+        - name: core-internal-certs
+          mountPath: /etc/harbor/ssl/core
+        {{- end }}
+        {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolumeMount" . | indent 8 }}
+        {{- end }}
       containers:
       - name: core
         image: {{ .Values.core.image.repository }}:{{ .Values.core.image.tag }}
@@ -93,6 +114,8 @@ spec:
         ports:
         - containerPort: {{ template "harbor.core.containerPort" . }}
         volumeMounts:
+        - name: ca-certificates
+          mountPath: /var/lib/ca-certificates
         - name: config
           mountPath: /etc/core/app.conf
           subPath: app.conf
@@ -125,6 +148,8 @@ spec:
 {{ toYaml .Values.core.resources | indent 10 }}
 {{- end }}
       volumes:
+      - name: "ca-certificates"
+        emptyDir: {}
       - name: config
         configMap:
           name: {{ template "harbor.core" . }}

--- a/templates/jobservice/jobservice-dpl.yaml
+++ b/templates/jobservice/jobservice-dpl.yaml
@@ -44,6 +44,28 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      initContainers:
+      - name: "install-certificates"
+        securityContext:
+          runAsUser: 0
+        image: {{ .Values.jobservice.image.repository }}:{{ .Values.jobservice.image.tag }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        command: ["/bin/sh"]
+        args: [
+            '-c',
+            '/usr/bin/harbor-install-cert.sh &&
+            cp -ar /var/lib/ca-certificates/* /tmp/ca-certificates' ]
+        volumeMounts:
+        - name: ca-certificates
+          mountPath: /tmp/ca-certificates
+          readOnly: false
+        {{- if .Values.internalTLS.enabled }}
+        - name: jobservice-internal-certs
+          mountPath: /etc/harbor/ssl/jobservice
+        {{- end }}
+        {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolumeMount" . | indent 8 }}
+        {{- end }}
       containers:
       - name: jobservice
         image: {{ .Values.jobservice.image.repository }}:{{ .Values.jobservice.image.tag }}
@@ -90,6 +112,8 @@ spec:
         ports:
         - containerPort: {{ template "harbor.jobservice.containerPort" . }}
         volumeMounts:
+        - name: ca-certificates
+          mountPath: /var/lib/ca-certificates
         - name: jobservice-config
           mountPath: /etc/jobservice/config.yml
           subPath: config.yml
@@ -104,6 +128,8 @@ spec:
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}
         {{- end }}
       volumes:
+      - name: "ca-certificates"
+        emptyDir: {}
       - name: jobservice-config
         configMap:
           name: "{{ template "harbor.jobservice" . }}"

--- a/templates/registry/registry-dpl.yaml
+++ b/templates/registry/registry-dpl.yaml
@@ -36,7 +36,7 @@ spec:
 {{- end }}
     spec:
       securityContext:
-        fsGroup: 10000
+        fsGroup: 10001
 {{- if .Values.registry.serviceAccountName }}
       serviceAccountName: {{ .Values.registry.serviceAccountName }}
 {{- end -}}
@@ -44,6 +44,48 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      initContainers:
+      - name: "change-pemission-of-directory"
+        securityContext:
+          runAsUser: 0
+        image: {{ .Values.registry.registry.image.repository }}:{{ .Values.registry.registry.image.tag }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        command: ["/bin/sh"]
+        args: [
+            "-c",
+            "chown -R registry:registry {{ .Values.persistence.imageChartStorage.filesystem.rootdirectory }} &&
+            chmod -R g+w {{ .Values.persistence.imageChartStorage.filesystem.rootdirectory }}"
+        ]
+        volumeMounts:
+        - name: registry-data
+          mountPath: {{ .Values.persistence.imageChartStorage.filesystem.rootdirectory }}
+          subPath: {{ .Values.persistence.persistentVolumeClaim.registry.subPath }}
+      - name: "install-certificates"
+        securityContext:
+          runAsUser: 0
+        image: {{ .Values.registry.registry.image.repository }}:{{ .Values.registry.registry.image.tag }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        command: ["/bin/sh"]
+        args: [
+            '-c',
+            '/usr/bin/harbor-install-cert.sh &&
+            cp -ar /var/lib/ca-certificates/* /tmp/ca-certificates' ]
+        volumeMounts:
+        - name: ca-certificates
+          mountPath: /tmp/ca-certificates
+          readOnly: false
+        {{- if .Values.internalTLS.enabled }}
+        - name: registry-internal-certs
+          mountPath: /etc/harbor/ssl/registry
+        {{- end }}
+        {{- if .Values.persistence.imageChartStorage.caBundleSecretName }}
+        - name: storage-service-ca
+          mountPath: /harbor_cust_cert/custom-ca-bundle.crt
+          subPath: ca.crt
+        {{- end }}
+        {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolumeMount" . | indent 8 }}
+        {{- end }}
       containers:
       - name: registry
         image: {{ .Values.registry.registry.image.repository }}:{{ .Values.registry.registry.image.tag }}
@@ -93,6 +135,8 @@ spec:
         - containerPort: {{ template "harbor.registry.containerPort" . }}
         - containerPort: 5001
         volumeMounts:
+        - name: ca-certificates
+          mountPath: /var/lib/ca-certificates
         - name: registry-data
           mountPath: {{ .Values.persistence.imageChartStorage.filesystem.rootdirectory }}
           subPath: {{ .Values.persistence.persistentVolumeClaim.registry.subPath }}
@@ -177,6 +221,8 @@ spec:
         ports:
         - containerPort: {{ template "harbor.registryctl.containerPort" . }}
         volumeMounts:
+        - name: ca-certificates
+          mountPath: /var/lib/ca-certificates
         - name: registry-data
           mountPath: {{ .Values.persistence.imageChartStorage.filesystem.rootdirectory }}
           subPath: {{ .Values.persistence.persistentVolumeClaim.registry.subPath }}
@@ -204,6 +250,8 @@ spec:
 {{ include "harbor.caBundleVolumeMount" . | indent 8 }}
         {{- end }}
       volumes:
+      - name: "ca-certificates"
+        emptyDir: {}
       - name: registry-htpasswd
         secret:
           secretName: {{ template "harbor.registry" . }}

--- a/templates/trivy/trivy-sts.yaml
+++ b/templates/trivy/trivy-sts.yaml
@@ -30,6 +30,7 @@ spec:
 {{ toYaml .Values.trivy.podAnnotations | indent 8 }}
 {{- end }}
     spec:
+      automountServiceAccountToken: false
 {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -37,13 +38,49 @@ spec:
 {{- if .Values.trivy.serviceAccountName }}
       serviceAccountName: {{ .Values.trivy.serviceAccountName }}
 {{- end }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 10000
-        fsGroup: 10000
-      automountServiceAccountToken: false
+      initContainers:
+        - name: "change-directory-owner"
+          securityContext:
+            runAsUser: 0
+          image: {{ .Values.trivy.image.repository }}:{{ .Values.trivy.image.tag }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          command: ["/bin/sh"]
+          args: [
+            "-c",
+            "chown -R scanner:scanner /home/scanner/.cache"
+          ]
+          volumeMounts:
+          - name: data
+            mountPath: /home/scanner/.cache
+            subPath: {{ .Values.persistence.persistentVolumeClaim.trivy.subPath }}
+            readOnly: false
+        - name: "install-certificates"
+          securityContext:
+            runAsUser: 0
+          image: {{ .Values.trivy.image.repository }}:{{ .Values.trivy.image.tag }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          command: ["/bin/sh"]
+          args: [
+             '-c',
+             '/usr/bin/harbor-install-cert.sh &&
+             cp -ar /var/lib/ca-certificates/* /tmp/ca-certificates' ]
+          volumeMounts:
+          - name: ca-certificates
+            mountPath: /tmp/ca-certificates
+            readOnly: false
+          {{- if .Values.internalTLS.enabled }}
+          - name: trivy-internal-certs
+            mountPath: /etc/harbor/ssl/trivy
+          {{- end }}
+          {{- if .Values.caBundleSecretName }}
+{{ include "harbor.caBundleVolumeMount" . | indent 10 }}
+          {{- end }}
       containers:
         - name: trivy
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 10000
+            fsGroup: 10000
           image: {{ .Values.trivy.image.repository }}:{{ .Values.trivy.image.tag }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           securityContext:
@@ -110,6 +147,8 @@ spec:
             - name: api-server
               containerPort: {{ template "harbor.trivy.containerPort" . }}
           volumeMounts:
+          - name: ca-certificates
+            mountPath: /var/lib/ca-certificates
           - name: data
             mountPath: /home/scanner/.cache
             subPath: {{ .Values.persistence.persistentVolumeClaim.trivy.subPath }}
@@ -141,8 +180,10 @@ spec:
             failureThreshold: 3
           resources:
 {{ toYaml .Values.trivy.resources | indent 12 }}
-      {{- if or (or .Values.internalTLS.enabled .Values.caBundleSecretName) (or (not .Values.persistence.enabled) $trivy.existingClaim) }}
       volumes:
+      - name: "ca-certificates"
+        emptyDir: {}
+      {{- if or (or .Values.internalTLS.enabled .Values.caBundleSecretName) (or (not .Values.persistence.enabled) $trivy.existingClaim) }}
       {{- if .Values.internalTLS.enabled }}
       - name: trivy-internal-certs
         secret:


### PR DESCRIPTION
Trying to get rid of containers run by root by introducing new initcontainers. New images can be found here:

https://build.suse.de/project/show/home:jsuchome:branches:Devel:CAPS:Registry:2.1

My values modifications:
```yaml
expose:
  ingress:
    hosts:
      core: core-10-86-0-237.nip.io
      notary: notary-10-86-0-237.nip.io
externalURL: https://core-10-86-0-237.nip.io
core:
  image:
    repository: registry.suse.de/home/jsuchome/branches/devel/caps/registry/2.1/containers/harbor/harbor-core
registry:
  registry:
    image:
      repository: registry.suse.de/home/jsuchome/branches/devel/caps/registry/2.1/containers/harbor/harbor-registry
  controller:
    image:
      repository: registry.suse.de/home/jsuchome/branches/devel/caps/registry/2.1/containers/harbor/harbor-registryctl
jobservice:
  image:
    repository: registry.suse.de/home/jsuchome/branches/devel/caps/registry/2.1/containers/harbor/harbor-jobservice
chartmuseum:
  enabled: false
clair:
  enabled: false
trivy:
  enabled: true
  image:
    repository: registry.suse.de/home/jsuchome/branches/devel/caps/registry/2.1/containers/harbor/harbor-trivy-adapter
notary:
  enabled: false
updateStrategy:
  type: Recreate
imagePullPolicy: Always
internalTLS:
  enabled: true
```
