### PR TITLE
Add explicit runAsUser values to confirm with PodSecurityPolicy

### DIFF
--- a/templates/nginx/deployment.yaml
+++ b/templates/nginx/deployment.yaml
@@ -35,6 +35,7 @@ spec:
 {{- end }}
       securityContext:
         fsGroup: 10000
+        runAsUser: 10000
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -26,6 +26,8 @@ spec:
 {{ toYaml .Values.portal.podAnnotations | indent 8 }}
 {{- end }}
     spec:
+      securityContext:
+        runAsUser: 498
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/templates/portal/deployment.yaml
+++ b/templates/portal/deployment.yaml
@@ -27,7 +27,7 @@ spec:
 {{- end }}
     spec:
       securityContext:
-        runAsUser: 498
+        runAsUser: 10000
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/templates/redis/statefulset.yaml
+++ b/templates/redis/statefulset.yaml
@@ -26,6 +26,7 @@ spec:
     spec:
       securityContext:
         fsGroup: 999
+        runAsUser: 999
 {{- if .Values.redis.internal.serviceAccountName }}
       serviceAccountName: {{ .Values.redis.internal.serviceAccountName }}
 {{- end -}}


### PR DESCRIPTION
If PodSecurityPolicy enforces MustRunAsNonRoot rule for containers,
it has to know UIDs of the users running the containers, not just
user name, otherwise it is unable to determine if a user is root.